### PR TITLE
Remove schedule triggers - dispatch externally for reliability

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -1,8 +1,10 @@
 name: Monitor & Deploy Status Page
 
+# MODIFIED: Removed schedule trigger — now dispatched externally via crontab.
+# Keeps ubuntu-latest since this repo stays public (GitHub Pages requirement).
+
 on:
-  schedule:
-    - cron: '*/5 * * * *'
+  # schedule removed — dispatched by external crontab every 5 minutes
   push:
     branches: [main]
     paths:

--- a/.github/workflows/statuspage.yml
+++ b/.github/workflows/statuspage.yml
@@ -1,8 +1,10 @@
 name: Sync to Atlassian Statuspage
 
+# MODIFIED: Removed schedule trigger — now dispatched externally via crontab.
+# Keeps ubuntu-latest since this repo stays public.
+
 on:
-  schedule:
-    - cron: '*/5 * * * *'
+  # schedule removed — dispatched by external crontab every 5 minutes (30s offset)
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

- Removes `schedule:` triggers from `monitor.yml` and `statuspage.yml`
- Scheduling handled externally by crontab on Oracle VM via `workflow_dispatch`
- No runner change - this repo stays public, so `ubuntu-latest` is kept

## Why

- GitHub cron has unreliable timing for the every-5-minute schedule
- GitHub auto-disables scheduled workflows after 60 days of repo inactivity
- External dispatch gives exact 5-minute intervals with no auto-disable risk
- This repo stays public because it needs free GitHub Pages

## Schedule (maintained externally)

| Workflow | Frequency |
|----------|-----------|
| `monitor.yml` | Every 5 minutes |
| `statuspage.yml` | Every 5 minutes (30s offset) |

## Test plan

- [ ] Manually trigger `monitor.yml` via Run workflow - confirm Pages deploys
- [ ] Manually trigger `statuspage.yml` - confirm Statuspage sync works
- [ ] Test dispatch from Oracle VM: `./dispatch.sh status-page monitor.yml`
- [ ] Verify push-triggered runs still work (push to github-pages/ or config/)

## Related

Runner infrastructure: caelicode/runner-infrastructure
