### PR TITLE
fix: prevent orphaned Pages deployments

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -21,7 +21,7 @@ permissions:
 
 concurrency:
   group: github-pages
-  cancel-in-progress: true
+  cancel-in-progress: false  # must be false — true can orphan Pages deployments
 
 jobs:
   monitor-and-deploy:


### PR DESCRIPTION
## Summary
- Changes `cancel-in-progress` from `true` to `false` in the Pages deployment concurrency group
- Prevents workflow cancellation mid-deploy which orphans deployments in GitHub's internal Pages queue

## Root cause
When `cancel-in-progress: true`, a new workflow run cancels any in-progress run. If the cancelled run has already submitted a Pages deployment to GitHub's backend, that deployment becomes a zombie — the Pages API considers it "in progress" but the cancel API says it's "finished". This blocks every subsequent deployment attempt.

## Test plan
- [ ] Verify next Monitor & Deploy dispatch succeeds
- [ ] Confirm no deployment collisions over 30 minutes of dispatches
