### PR TITLE
fix: use GitHub App token for reconcile PR creation

### DIFF
--- a/.github/workflows/reconcile.yml
+++ b/.github/workflows/reconcile.yml
@@ -12,17 +12,22 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   reconcile:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -49,7 +54,7 @@ jobs:
 
       - name: Create PR with generated configs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git diff --quiet config/checks.json config/statuspage.json && exit 0
           BRANCH="chore/reconcile-configs-$(date +%s)"


### PR DESCRIPTION
Replace GITHUB_TOKEN with a token minted from the caelicode-org-manager GitHub App via actions/create-github-app-token. The org-level workflow permissions block GITHUB_TOKEN from creating PRs, but App tokens are not subject to that restriction. The App token is also passed to checkout so git push uses it for authentication.