### PR TITLE
fix: adjust latency thresholds to match actual endpoint performance

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -108,11 +108,11 @@ settings:
       operational: 95
       degraded: 75
     latency_ms:
-      operational: 200
-      degraded: 1000
+      operational: 1000
+      degraded: 3000
 ```
 
-These are global defaults. A component is `operational` when reachability >= 95% AND latency <= 200ms. It becomes `degraded_performance` when either drops below operational but stays above degraded thresholds. Below both, it's `major_outage`.
+These are global defaults. A component is `operational` when reachability >= 95% AND latency <= 1000ms. It becomes `degraded_performance` when either drops below operational but stays above degraded thresholds. Below both, it's `major_outage`.
 
 Commit and push. Changes apply on the next monitoring run (within 5 minutes).
 
@@ -134,11 +134,11 @@ endpoints:
     metric: false
     thresholds:
       latency_ms:
-        operational: 500
-        degraded: 2000
+        operational: 2000
+        degraded: 5000
 ```
 
-Only the thresholds you specify are overridden. In this example, latency uses 500ms/2000ms while reachability inherits the global 95%/75%.
+Only the thresholds you specify are overridden. In this example, latency uses 2000ms/5000ms while reachability inherits the global 95%/75%.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ settings:
       operational: 95
       degraded: 75
     latency_ms:
-      operational: 200
-      degraded: 1000
+      operational: 1000
+      degraded: 3000
 
 incidents:
   auto_create: true
@@ -184,8 +184,8 @@ endpoints:
     metric: true
     thresholds:
       latency_ms:
-        operational: 500
-        degraded: 2000
+        operational: 2000
+        degraded: 5000
 ```
 
 Per-endpoint thresholds are optional. When provided, they override the global thresholds for that endpoint only. Set `component: true` to sync to Statuspage, and `metric: true` to track latency metrics.
@@ -262,7 +262,7 @@ Rather than tracking consecutive failures (which needs persistent state between 
 | Metric | Operational | Degraded | Major Outage |
 |--------|-------------|----------|--------------|
 | Reachability | >= 95% | >= 75% | < 75% |
-| Latency | <= 200ms | <= 1000ms | > 1000ms |
+| Latency | <= 1000ms | <= 3000ms | > 3000ms |
 
 The worst of reachability and latency determines the component status. The worst component determines overall status. If either metric is unavailable (Prometheus returns no data), the component conservatively defaults to `major_outage`.
 

--- a/config.yaml
+++ b/config.yaml
@@ -9,8 +9,8 @@ settings:
       operational: 95
       degraded: 75
     latency_ms:
-      operational: 200
-      degraded: 1000
+      operational: 1000
+      degraded: 3000
 
 incidents:
   auto_create: true
@@ -28,6 +28,10 @@ endpoints:
     probes: [1, 2, 3]
     component: true
     metric: true
+    thresholds:
+      latency_ms:
+        operational: 1500
+        degraded: 3000
 
   caelicode-com:
     name: "caelicode.com"
@@ -38,9 +42,6 @@ endpoints:
     component: true
     metric: true
     thresholds:
-      reachability:
-        operational: 95
-        degraded: 75
       latency_ms:
-        operational: 2000
+        operational: 3000
         degraded: 5000


### PR DESCRIPTION
Global default raised from 200ms/1000ms to 1000ms/3000ms — the old 200ms operational threshold was unrealistically low and caused both endpoints to be permanently flagged as degraded or outage despite being fully reachable. Per-endpoint overrides added for httpbin.org (1500ms/3000ms) and caelicode.com adjusted from 2000ms to 3000ms operational to avoid edge-case flapping at ~2100ms actual latency.