### PR TITLE
fix: SM registration falls through to install when check list is empty

### DIFF
--- a/monitoring/grafana_client.py
+++ b/monitoring/grafana_client.py
@@ -108,16 +108,17 @@ class SyntheticMonitoringClient:
                 timeout=30,
             )
             if probe.status_code == 200:
-                self._access_token = self.config.synthetic_monitoring_token
                 checks = probe.json()
                 if isinstance(checks, list) and checks:
+                    self._access_token = self.config.synthetic_monitoring_token
                     self._tenant_id = checks[0].get("tenantId", 0)
-                else:
-                    self._tenant_id = 0
+                    logger.info(
+                        "Using existing SM access token (tenant: %s)", self._tenant_id
+                    )
+                    return self._access_token, self._tenant_id
                 logger.info(
-                    "Using existing SM access token (tenant: %s)", self._tenant_id
+                    "SM token valid but no checks exist — registering to get tenant ID"
                 )
-                return self._access_token, self._tenant_id
         except requests.RequestException:
             pass
 


### PR DESCRIPTION
On a fresh Grafana Cloud account with no existing checks, the register method was setting tenant_id to 0 and returning immediately. The SM API then rejected check creation with 400 because tenant 0 is invalid. Now falls through to the /register/install endpoint to get the real tenant ID when the check list is empty.