### PR TITLE
fix: remove hardcoded probe IDs, resolve dynamically from SM API

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,7 +25,6 @@ endpoints:
     url: "https://httpbin.org/get"
     description: "Example endpoint — replace with your own"
     frequency: 60000
-    probes: [1, 2, 3]
     component: true
     metric: true
     thresholds:
@@ -38,7 +37,6 @@ endpoints:
     url: "https://caelicode.com"
     description: "CaeliCode Solutions website"
     frequency: 300000
-    probes: [1, 2, 3]
     component: true
     metric: true
     thresholds:

--- a/monitoring/grafana_client.py
+++ b/monitoring/grafana_client.py
@@ -210,13 +210,15 @@ class SyntheticMonitoringClient:
 
     def get_default_probe_ids(self, count: int = 3) -> list:
         probes = self.list_probes()
-        public_probes = [
-            p for p in probes
-            if not p.get("public", True) is False
-        ]
+        public_probes = [p for p in probes if p.get("public") is True]
         if not public_probes:
             public_probes = probes
-        return [p["id"] for p in public_probes[:count]]
+        selected = [p["id"] for p in public_probes[:count]]
+        logger.info(
+            "Resolved %d probe IDs from %d total (%d public): %s",
+            len(selected), len(probes), len(public_probes), selected,
+        )
+        return selected
 
     def list_checks(self) -> list:
         self._ensure_registered()

--- a/reconcile.py
+++ b/reconcile.py
@@ -121,8 +121,9 @@ def reconcile_grafana(config, sm_client):
             needs_update = (
                 existing.get("target") != url
                 or existing.get("frequency") != frequency
-                or sorted(existing.get("probes", [])) != sorted(probes)
             )
+            if probes is not None:
+                needs_update = needs_update or sorted(existing.get("probes", [])) != sorted(probes)
 
             if needs_update:
                 try:


### PR DESCRIPTION
config.yaml had probes: [1, 2, 3] which are invalid on the new Grafana Cloud account. Probe IDs are instance-specific. Removed hardcoded values so the SM client fetches available public probes via GET /api/v1/probe/list and uses the first 3.