### PR TITLE
Remove Example API endpoint

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,18 +20,6 @@ incidents:
   quiet_period_minutes: 60
 
 endpoints:
-  example-api:
-    name: "Example API"
-    url: "https://httpbin.org/get"
-    description: "Example endpoint — replace with your own"
-    frequency: 60000
-    component: true
-    metric: true
-    thresholds:
-      latency_ms:
-        operational: 1500
-        degraded: 3000
-
   caelicode-com:
     name: "caelicode.com"
     url: "https://caelicode.com"


### PR DESCRIPTION
## Summary
- Removes the `example-api` placeholder endpoint from `config.yaml`
- After merge, run the Reconcile workflow manually with `allow_deletions: true` to clean up the orphaned Grafana check and Statuspage component

## What this affects
- `config.yaml`: removes `example-api` endpoint block
- On reconcile: `checks.json` and `statuspage.json` will be regenerated without Example API
- Grafana Synthetic Monitoring: orphaned check will be deleted (with allow_deletions)
- Atlassian Statuspage: orphaned component will be deleted (with allow_deletions)